### PR TITLE
add selectAll() method

### DIFF
--- a/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectRecyclerViewAdapter.java
+++ b/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectRecyclerViewAdapter.java
@@ -149,6 +149,18 @@ public abstract class DragSelectRecyclerViewAdapter<VH extends RecyclerView.View
         fireSelectionListener();
     }
 
+    public final void selectAll() {
+        int max = getItemCount();
+        mSelectedIndices.clear();
+        for (int i = 0; i < max; i++) {
+            if (isIndexSelectable(i)) {
+                mSelectedIndices.add(i);
+            }
+        }
+        notifyDataSetChanged();
+        fireSelectionListener();
+    }
+
     public final void clearSelected() {
         mSelectedIndices.clear();
         notifyDataSetChanged();


### PR DESCRIPTION
when adapter data is large, selecting all by using selectRange() method calls too much SelectionListener and makes the UI not response. So I add selectAll() method for less calling the listener callback, firing the listener only once.
