### PR TITLE
Fix for an unexpected behavior when selecting

### DIFF
--- a/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectRecyclerView.java
+++ b/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectRecyclerView.java
@@ -181,7 +181,7 @@ public class DragSelectRecyclerView extends RecyclerView {
 
     private int getItemPosition(MotionEvent e) {
         final View v = findChildViewUnder(e.getX(), e.getY());
-        if (v == null) return -2;
+        if (v == null) return NO_POSITION;
         if (v.getTag() == null || !(v.getTag() instanceof ViewHolder))
             throw new IllegalStateException("Make sure your adapter makes a call to super.onBindViewHolder(), and doesn't override itemView tags.");
         final ViewHolder holder = (ViewHolder) v.getTag();
@@ -271,7 +271,7 @@ public class DragSelectRecyclerView extends RecyclerView {
                 }
 
                 // Drag selection logic
-                if (itemPosition != -2 && mLastDraggedIndex != itemPosition) {
+                if (itemPosition != NO_POSITION && mLastDraggedIndex != itemPosition) {
                     mLastDraggedIndex = itemPosition;
                     if (mMinReached == -1) mMinReached = mLastDraggedIndex;
                     if (mMaxReached == -1) mMaxReached = mLastDraggedIndex;


### PR DESCRIPTION
The method `RecyclerView#getAdapterPosition() `returns `NO_POSITION` until the next layout pass when `RecyclerView.Adapter#notifyDataSetChanged()` has been called.

The code on `//Drag selection logic` was assuming that the value of `itemPosition` woud be `-2` or the index of the pressed item, but if `notifyDataSetChanged()` had been called, it was passing the conditional with the value `NO_POSITION` for `itemPosition`, and therefore selecting the whole range from -1 to the pressed item.

This was causing the next behavior in some situations.

![selection-error](https://cloud.githubusercontent.com/assets/3061616/20174872/40ddba34-a740-11e6-9fed-56822bda9fe5.gif)

 The code to replicate the error can be found on 36e2910ca9e3152e37c1e0be363ad75f34b1a76f.