### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the following to your module's `build.gradle` file:
 ```Gradle
 dependencies {
     // ... other dependencies
-    compile 'com.afollestad:drag-select-recyclerview:1.0.0'
+    implementation 'com.afollestad:drag-select-recyclerview:1.0.0'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.