### PR TITLE
Stop drag selection after ACTION_UP on edge case

### DIFF
--- a/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectTouchListener.kt
+++ b/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectTouchListener.kt
@@ -196,6 +196,9 @@ class DragSelectTouchListener private constructor(
       }
     }
 
+    if(result && event.action == ACTION_UP){
+      onDragSelectionStop()
+    }
     return result
   }
 
@@ -210,11 +213,7 @@ class DragSelectTouchListener private constructor(
 
     when (action) {
       ACTION_UP -> {
-        dragSelectActive = false
-        inTopHotspot = false
-        inBottomHotspot = false
-        autoScrollHandler.removeCallbacks(autoScrollRunnable)
-        this.notifyAutoScrollListener(false)
+        onDragSelectionStop()
         return
       }
       ACTION_MOVE -> {
@@ -290,6 +289,14 @@ class DragSelectTouchListener private constructor(
         return
       }
     }
+  }
+
+  private fun onDragSelectionStop() {
+    dragSelectActive = false
+    inTopHotspot = false
+    inBottomHotspot = false
+    autoScrollHandler.removeCallbacks(autoScrollRunnable)
+    this.notifyAutoScrollListener(false)
   }
 
   @RestrictTo(Scope.LIBRARY_GROUP)

--- a/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectTouchListener.kt
+++ b/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectTouchListener.kt
@@ -196,7 +196,7 @@ class DragSelectTouchListener private constructor(
       }
     }
 
-    if(result && event.action == ACTION_UP){
+    if (result && event.action == ACTION_UP) {
       onDragSelectionStop()
     }
     return result


### PR DESCRIPTION
As commented on the issue thread #34, the drag selection was not terminated when the user started it with a long press but didn't move the finger before the `ACTION_UP` event. 

The proposed solution is to terminate the drag selection when an `ACTION_UP` event is detected in either the `onTouchEvent` or `onInterceptTouchEvent`.