### PR TITLE
Improved items selectability check, and stop scrolling when an item is not selectable 

### DIFF
--- a/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectReceiver.kt
+++ b/library/src/main/java/com/afollestad/dragselectrecyclerview/DragSelectReceiver.kt
@@ -20,8 +20,6 @@ import androidx.annotation.CheckResult
 /** @author Aidan Follestad (afollestad) */
 interface DragSelectReceiver {
 
-  @CheckResult fun getItemCount(): Int
-
   fun setSelected(
     index: Int,
     selected: Boolean
@@ -29,5 +27,5 @@ interface DragSelectReceiver {
 
   @CheckResult fun isSelected(index: Int): Boolean
 
-  @CheckResult fun isIndexSelectable(index: Int): Boolean
+  @CheckResult fun isSelectable(index: Int): Boolean
 }

--- a/sample/src/main/java/com/afollestad/dragselectrecyclerviewsample/RecyclicalTranslator.kt
+++ b/sample/src/main/java/com/afollestad/dragselectrecyclerviewsample/RecyclicalTranslator.kt
@@ -20,7 +20,6 @@ import com.afollestad.recyclical.datasource.SelectableDataSource
 
 fun SelectableDataSource<*>.asDragSelectReceiver(): DragSelectReceiver {
   return object : DragSelectReceiver {
-    override fun getItemCount(): Int = size()
 
     override fun setSelected(
       index: Int,
@@ -31,6 +30,6 @@ fun SelectableDataSource<*>.asDragSelectReceiver(): DragSelectReceiver {
 
     override fun isSelected(index: Int): Boolean = isSelectedAt(index)
 
-    override fun isIndexSelectable(index: Int): Boolean = true
+    override fun isSelectable(index: Int): Boolean = true
   }
 }


### PR DESCRIPTION
Main changes:
- removed `getItemCount ` (was not used at all)
- renamed `isIndexSelectable ` to `isSelectable ` for consistency
- check items selectable also during selection, not only at first selection
- stop drag to select when an item cannot be selected
- added a `DragToSelectListener ` in order to monitor activation/deactivation of drag to select